### PR TITLE
Use the 3.28 runtime

### DIFF
--- a/org.gnome.Polari.json
+++ b/org.gnome.Polari.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Polari",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "polari",
     "x-run-args": ["--test-instance"],


### PR DESCRIPTION
Polari was updated to its 3.28 release some time ago, but still uses the GNOME 3.28 Platform/Sdk.