### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Polari.json
+++ b/org.gnome.Polari.json
@@ -37,9 +37,6 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options": {
-        "cflags": "-O2 -g"
-    },
     "cleanup": ["*.la",
                 "/include",
                 "/lib/pkgconfig",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.