### PR TITLE
Only use host log dir if it already exists

### DIFF
--- a/tpl-override-basedir.patch
+++ b/tpl-override-basedir.patch
@@ -1,27 +1,52 @@
-From c0349769acc1289189110f0a2a7d24401fbfae08 Mon Sep 17 00:00:00 2001
+From 1fbc43bbc65cbea2cf97e51447851c417df62bce Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Florian=20M=C3=BCllner?= <fmuellner@gnome.org>
 Date: Sat, 20 Feb 2016 04:24:57 +0100
-Subject: [PATCH] log-store-xml: Allow overriding basedir
+Subject: [PATCH] log-store-xml: Allow to override base dir ...
 
+... but only if it exists already.
 ---
- telepathy-logger/log-store-xml.c | 4 ++++
- 1 file changed, 4 insertions(+)
+ telepathy-logger/log-store-xml.c | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
 
 diff --git a/telepathy-logger/log-store-xml.c b/telepathy-logger/log-store-xml.c
-index be881d0..01676fa 100644
+index be881d0..9863329 100644
 --- a/telepathy-logger/log-store-xml.c
 +++ b/telepathy-logger/log-store-xml.c
-@@ -1744,6 +1744,10 @@ log_store_xml_get_basedir (TplLogStoreXml *self)
+@@ -1737,19 +1737,30 @@ log_store_xml_get_basedir (TplLogStoreXml *self)
+   if (self->priv->basedir == NULL)
+     {
+       gchar *dir;
+-      const char *user_data_dir;
++      const char *user_data_dir = NULL;
+       const char *name;
+ 
++      name = _tpl_log_store_get_name ((TplLogStore *) self);
++
+       if (self->priv->test_mode && g_getenv ("TPL_TEST_LOG_DIR") != NULL)
          {
            user_data_dir = g_getenv ("TPL_TEST_LOG_DIR");
          }
+-      else
 +      else if (g_getenv ("TPL_LOG_DIR") != NULL)
-+        {
-+          user_data_dir = g_getenv ("TPL_LOG_DIR");
-+        }
-       else
          {
-           user_data_dir = g_get_user_data_dir ();
+-          user_data_dir = g_get_user_data_dir ();
++          g_autofree char *try_dir = NULL;
++
++          user_data_dir = g_getenv ("TPL_LOG_DIR");
++          try_dir = g_build_path (G_DIR_SEPARATOR_S,
++                                  user_data_dir, name, "logs",
++                                  NULL);
++          if (!g_file_test (try_dir, G_FILE_TEST_EXISTS))
++            user_data_dir = NULL;
+         }
+ 
+-      name = _tpl_log_store_get_name ((TplLogStore *) self);
++      if (!user_data_dir)
++        user_data_dir = g_get_user_data_dir ();
++
+       dir = g_build_path (G_DIR_SEPARATOR_S, user_data_dir, name, "logs",
+           NULL);
+       log_store_xml_set_basedir (self, dir);
 -- 
-2.7.1
+2.20.1
 


### PR DESCRIPTION
We point telepathy-logger to the "regular" data dir, as the D-Bus
service may run on the host. However if it doesn't and the directory
doesn't exist yet, the sandbox doesn't have permissions to create it.

Instead of poking another hole in the sandbox, fall back to the
sandbox data dir in that case.

Fixes https://github.com/flathub/org.gnome.Polari/issues/5