### PR TITLE
Enable dri

### DIFF
--- a/org.gnome.Polari.json
+++ b/org.gnome.Polari.json
@@ -12,6 +12,8 @@
         "--socket=wayland",
         /* Needs network, obviously */
         "--share=network",
+        /* GTK4 */
+        "--device=dri",
         /* Our client name */
         "--own-name=org.freedesktop.Telepathy.Client.Polari",
         "--own-name=org.freedesktop.Telepathy.Client.Polari.*",


### PR DESCRIPTION
GTK4 wants to use hardware acceleration, so add the corresponding
permission (that somehow got lost in the gnome-nightly → flathub
move).
