### PR TITLE
Update flatpak runtime to Gnome 49

### DIFF
--- a/org.gnome.Polari.json
+++ b/org.gnome.Polari.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Polari",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "polari",
     "x-run-args": ["--test-instance"],


### PR DESCRIPTION
flatpak runtime gnome 47 is EOL, please update flatpak runtime to gnome 48/49, thank you. 